### PR TITLE
switch to lighter weight spacewalk-channel

### DIFF
--- a/providers/system.rb
+++ b/providers/system.rb
@@ -44,7 +44,7 @@ end
 
 def registered?
   registered = false
-  cmd = Mixlib::ShellOut.new('/usr/sbin/rhn-profile-sync')
+  cmd = Mixlib::ShellOut.new('/usr/sbin/spacewalk-channel --list')
   begin cmd.run_command
     rescue Errno::ENOENT
   end


### PR DESCRIPTION
rhn-profile-sync apparently is more heavy weight at scale than expected, spacewalk-channel is lighter weight but still actively communicates with rhn
